### PR TITLE
Add a missing word (for a Wired *writer* at his home office).

### DIFF
--- a/Lord-of-the-Files.en.txt
+++ b/Lord-of-the-Files.en.txt
@@ -32,7 +32,7 @@ So in 2005, Torvalds created Git, version control software specifically designed
 
 Back in the 1990s, forking was supposed to be a bad thing. It’s what created all of those competing, incompatible versions of Unix. For a while, there was a big fear that someone would somehow create their own fork of Linux, a version of the operating system that wouldn’t run the same programs or work in the same way. But in the Git world, forking is good. The trick was to make sure the improvements people worked out could be shared back with the community. It’s better to let people fork a project and tinker away with their own changes, than to shut them out altogether by only letting a few trusted authorities touch the code.
 
-On a rare sunny February day in Portland, Torvalds demonstrates Git for a Wired at his home office. With a few keystrokes, he quickly spots two new kernel submissions that change the same kernel code in different ways, a potential problem source.
+On a rare sunny February day in Portland, Torvalds demonstrates Git for a Wired writer at his home office. With a few keystrokes, he quickly spots two new kernel submissions that change the same kernel code in different ways, a potential problem source.
 
 The old regime “makes it very hard to start radical new branches because you generally need to convince the people involved in the status quo up-front about their need to support that radical branch,” Torvalds says. “In contrast, Git makes it easy to just ‘do it’ without asking for permission, and then come back later and show the end result off — telling people ‘look what I did, and I have the numbers to show that my approach is much better.’”
 


### PR DESCRIPTION
A really minor fix, mentioned in the article comments an hour ago.
